### PR TITLE
Fix toolbar visibility and improve Markdown highlighting

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -151,11 +151,15 @@ function resetToolbarStyles(toolbarElement, context) {
 
 
 function ensureToolbarVisible() {
-  if (docViewerToolbar) {
-    ensureToolbarVisible();
-const isMarkdown = currentActiveContainer?.dataset?.isMarkdown === 'true';
-    resetToolbarStyles(docViewerToolbar, isMarkdown ? "desde ensureToolbarVisible (Markdown)" : "desde ensureToolbarVisible (HTML)");
-  }
+  if (!docViewerToolbar) return;
+  const isMarkdown = currentActiveContainer?.dataset?.isMarkdown === 'true';
+  docViewerToolbar.classList.remove('hidden');
+  resetToolbarStyles(
+    docViewerToolbar,
+    isMarkdown
+      ? 'desde ensureToolbarVisible (Markdown)'
+      : 'desde ensureToolbarVisible (HTML)'
+  );
 }
 
 // --- EVENT LISTENERS ---
@@ -355,8 +359,8 @@ async function openDoc(path, title) {
       targetViewer.innerHTML = `<pre>${content}</pre>`;
     }
     
-    if (typeof hljs !== 'undefined' && path.endsWith('.html')) {
-        targetViewer.querySelectorAll('pre code').forEach((block) => {
+    if (typeof hljs !== 'undefined') {
+        targetViewer.querySelectorAll('pre code').forEach(block => {
             hljs.highlightElement(block);
         });
     }


### PR DESCRIPTION
## Summary
- fix recursion bug in `ensureToolbarVisible`
- make code highlighting run for both HTML and Markdown documents

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840f0ff6fa083328903696e155abefa