### PR TITLE
Fix conflict in service worker

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -25,7 +25,6 @@ const urlsToCache = [
   '/test2/docs/documento2.html',
   '/test2/docs/documento3.html',
   '/test2/docs/documento4.html',
-  '/test2/docs/documento5..html',
   '/test2/docs/documento5.html',
   '/test2/docs/documento6.html',
   '/test2/docs/documento7.html',


### PR DESCRIPTION
## Summary
- remove stale path `documento5..html` from service worker cache list

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841009fa12883328fa6001cc727a136