### PR TITLE
Fix script load for main application

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,6 +107,6 @@
   // Inicializar highlight.js si tienes bloques de código
   // hljs.highlightAll(); // O llama después de cargar contenido dinámico
 </script>
-<script src="dist/app.js"></script>
+<script type="module" src="dist/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load app script as ES module to avoid syntax errors

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_684103920b6083329e83a51b7020052a